### PR TITLE
Fix build error under Linux 4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This repo contains a driver originally called `rtl8821AU_linux_v4.3.14_13455.201
 I originally got the source code off a cd that came with [this usb wifi adapter](https://www.amazon.com/Heiyo-Network-600Mbps-802-11ac-Wireless/dp/B01N2NJFPG).
 
 This driver have been tested on:
-    * Ubuntu 16.04.2 LTS with kernel 4.4.0-64-generic using a "Heiyo Network Wi-Fi Dongle 802.11ac"
-    * Ubuntu 16.04.2 LTS with kernel 4.10.0-32-generic using a "NetGear, Inc. A6100 AC600 DB Wireless Adapter"
+
+* Ubuntu 16.04.2 LTS with kernel 4.4.0-64-generic using a "Heiyo Network Wi-Fi Dongle 802.11ac"
+* Ubuntu 16.04.2 LTS with kernel 4.10.0-32-generic using a "NetGear, Inc. A6100 AC600 DB Wireless Adapter"
 
 ## Building
 ```

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# rtl8811au driver for recent version of ubuntu
+# Realtek RTL8811AU driver for recent version of ubuntu
 
 This repo contains a driver originally called `rtl8821AU_linux_v4.3.14_13455.20150212_BTCOEX20150128-51` with additional patches to get it to build on Ubuntu xenial 16.04.
 
 I originally got the source code off a cd that came with [this usb wifi adapter](https://www.amazon.com/Heiyo-Network-600Mbps-802-11ac-Wireless/dp/B01N2NJFPG).
 
-I tested on Ubuntu 16.04.2 LTS with kernel 4.4.0-64-generic using a "Heiyo Network Wi-Fi Dongle 802.11ac"
-
+This driver have been tested on:
+    * Ubuntu 16.04.2 LTS with kernel 4.4.0-64-generic using a "Heiyo Network Wi-Fi Dongle 802.11ac"
+    * Ubuntu 16.04.2 LTS with kernel 4.10.0-32-generic using a "NetGear, Inc. A6100 AC600 DB Wireless Adapter"
 
 ## Building
-
 ```
 sudo make clean
 make -j 8

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -1171,5 +1171,10 @@ __inline static u8 *myid(struct eeprom_priv *peepriv)
 #include <pci_hal.h>
 #endif
 
+static inline bool is_compat_task(void)
+{
+    return in_ia32_syscall() || in_x32_syscall();
+}
+
 #endif //__DRV_TYPES_H__
 


### PR DESCRIPTION
An error was raised while compiling with Ubuntu 16.04 (kernel 4.10.0-32-generic):
error: implicit declaration of function ‘is_compat_task‘